### PR TITLE
Fix escaped single quote not being recognised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.0.2 - 2020-04-14
+### Changed
+- Fix unrecognised escaped characters in quoted strings
+
 ## 0.0.1 - 2020-04-05
 - Initial release

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dataprep-wrangle-language",
   "displayName": "Cloud Dataprep Wrangle",
   "description": "Language support for Cloud Dataprep Wrangle by Trifacta®",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publisher": "chemistechlabs",
   "repository": {
     "type": "git",

--- a/syntaxes/wrangle.tmLanguage.json
+++ b/syntaxes/wrangle.tmLanguage.json
@@ -80,7 +80,7 @@
       "patterns": [
         {
           "name": "constant.character.escape",
-          "match": "\\."
+          "match": "\\\\."
         }
       ]
     },


### PR DESCRIPTION
Fixed bug reported on issue #1 

Before:
<img width="744" alt="Screen Shot 2020-04-14 at 20 41 48" src="https://user-images.githubusercontent.com/3738460/79288784-09a59300-7e9e-11ea-8231-f370802fd0a5.png">

After:
<img width="742" alt="Screen Shot 2020-04-14 at 22 16 23" src="https://user-images.githubusercontent.com/3738460/79288797-10340a80-7e9e-11ea-8e7e-51929a14dcf7.png">
